### PR TITLE
Hide Discover Button From Appearing On Groups

### DIFF
--- a/frontend/src/app/groups/page.js
+++ b/frontend/src/app/groups/page.js
@@ -150,9 +150,9 @@ export default function Groups() {
             ) : activeTab === 'my-groups' ? (
               <>
                 <p>You haven&apos;t joined any groups yet</p>
-                <Link href="/groups?tab=discover">
+                {/* <Link href="/groups?tab=discover">
                   <Button variant="primary">Discover Groups</Button>
-                </Link>
+                </Link> */}
               </>
             ) : (
               <>


### PR DESCRIPTION
Issue #49 

This PR aims to bring the following change to the main branch:

- Hide the discover button from appearing in the groups section.